### PR TITLE
Add records to /etc/hosts/ on local setup

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -23,6 +23,7 @@ type initOptions struct {
 	verbose     bool
 	mkCerts     bool
 	noIde       bool
+	setHosts    bool
 	gitopsImage string
 	editorImage string
 }
@@ -58,6 +59,7 @@ func newInitCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&o.noIde, "no-ide", false, "Do not start Bitswan Editor")
 	cmd.Flags().BoolVarP(&o.verbose, "verbose", "v", false, "Verbose output")
 	cmd.Flags().BoolVar(&o.mkCerts, "mkcerts", false, "Automatically generate local certificates using the mkcerts utility")
+	cmd.Flags().BoolVar(&o.setHosts, "set-hosts", false, "Automatically set hosts to /etc/hosts file")
 	cmd.Flags().StringVar(&o.gitopsImage, "gitops-image", "", "Custom image for the gitops")
 	cmd.Flags().StringVar(&o.editorImage, "editor-image", "", "Custom image for the editor")
 
@@ -433,6 +435,47 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		if err := runCommandVerbose(chownCom, o.verbose); err != nil {
 			return fmt.Errorf("failed to change ownership of workspace folder: %w", err)
 		}
+	}
+
+	// Set hosts to /etc/hosts file
+	if o.setHosts {
+		fmt.Println("Checking if the user has permission to write to /etc/hosts...")
+		fileInfo, err := os.Stat("/etc/hosts")
+		if err != nil {
+			return fmt.Errorf("error: %w", err)
+		}
+
+		// Check if the current user can write to the file
+		if fileInfo.Mode().Perm()&0200 == 0 {
+			return fmt.Errorf("user does not have permission to write to /etc/hosts")
+		}
+		fmt.Println("File /etc/hosts is writable")
+
+		hostsEntries := []string{
+			"127.0.0.1 " + gitopsName + "-gitops.bitswan.local",
+		}
+
+		if !o.noIde {
+			hostsEntries = append(hostsEntries, "127.0.0.1 "+gitopsName+"-editor.bitswan.local")
+		}
+
+		// Check if the entries already exist in /etc/hosts
+		for _, entry := range hostsEntries {
+			if exec.Command("grep", "-wq", entry, "/etc/hosts").Run() == nil {
+				return fmt.Errorf("hosts already set in /etc/hosts")
+			}
+		}
+
+		fmt.Println("Adding record to /etc/hosts...")
+		for _, entry := range hostsEntries {
+			cmdStr := "echo '" + entry + "' | sudo tee -a /etc/hosts"
+			chownCom := exec.Command("sh", "-c", cmdStr)
+			if err := runCommandVerbose(chownCom, o.verbose); err != nil {
+				return fmt.Errorf("unable to write into '/etc/hosts'. \n Please add the records manually")
+			}
+		}
+
+		fmt.Println("Records added to /etc/hosts successfully!")
 	}
 
 	gitopsImage := o.gitopsImage

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -191,8 +191,8 @@ func setHosts(gitopsName string, o *initOptions) error {
 	fmt.Println("Adding record to /etc/hosts...")
 	for _, entry := range hostsEntries {
 		cmdStr := "echo '" + entry + "' | sudo tee -a /etc/hosts"
-		chownCom := exec.Command("sh", "-c", cmdStr)
-		if err := runCommandVerbose(chownCom, o.verbose); err != nil {
+		addHostsCom := exec.Command("sh", "-c", cmdStr)
+		if err := runCommandVerbose(addHostsCom, o.verbose); err != nil {
 			return fmt.Errorf("unable to write into '/etc/hosts'. \n Please add the records manually")
 		}
 	}
@@ -324,10 +324,8 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Secure that --local flag is not used with --set-hosts or --mkcerts
-	if o.local {
-		if o.setHosts || o.mkCerts {
-			panic(fmt.Errorf("Cannot use --local flag with --set-hosts or --mkcerts"))
-		}
+	if o.local && (o.setHosts || o.mkCerts) {
+		panic(fmt.Errorf("Cannot use --local flag with --set-hosts or --mkcerts"))
 	}
 
 	inputCertsDir := o.certsDir
@@ -491,7 +489,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	if o.setHosts {
 		err := setHosts(gitopsName, o)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("\033[33m%s\033[0m\n", err)
 		}
 	}
 
@@ -499,7 +497,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 	if o.local {
 		err := setHosts(gitopsName, o)
 		if err != nil {
-			return fmt.Errorf("Error setting records to /etc/hosts: %v\n", err)
+			fmt.Printf("\033[33m%s\033[0m\n", err)
 		}
 
 		certDir, err := generateWildcardCerts(o.domain)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -328,6 +328,11 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		panic(fmt.Errorf("Cannot use --local flag with --set-hosts or --mkcerts"))
 	}
 
+	if o.local {
+		o.setHosts = true
+		o.mkCerts = true
+	}
+
 	inputCertsDir := o.certsDir
 
 	if o.mkCerts {
@@ -491,20 +496,6 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			fmt.Printf("\033[33m%s\033[0m\n", err)
 		}
-	}
-
-	// Set hosts to /etc/hosts file and generate local certificates
-	if o.local {
-		err := setHosts(gitopsName, o)
-		if err != nil {
-			fmt.Printf("\033[33m%s\033[0m\n", err)
-		}
-
-		certDir, err := generateWildcardCerts(o.domain)
-		if err != nil {
-			return fmt.Errorf("Error generating certificates: %v\n", err)
-		}
-		inputCertsDir = certDir
 	}
 
 	gitopsImage := o.gitopsImage

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -323,6 +323,13 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		fmt.Println("A running instance of Caddy with admin found")
 	}
 
+	// Secure that --local flag is not used with --set-hosts or --mkcerts
+	if o.local {
+		if o.setHosts || o.mkCerts {
+			panic(fmt.Errorf("Cannot use --local flag with --set-hosts or --mkcerts"))
+		}
+	}
+
 	inputCertsDir := o.certsDir
 
 	if o.mkCerts {


### PR DESCRIPTION
feat: Add records to /etc/hosts when --set-hosts is active + check for any duplicity in /etc/hosts