### PR TITLE
Remove api from URLs in init, update and register

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -681,7 +681,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 
 		fmt.Println("Getting automation server token...")
 
-		resp, err := sendRequest("GET", fmt.Sprintf("%s/api/automation-servers/token", automationConfig.AOCUrl), nil, automationConfig.AccessToken)
+		resp, err := sendRequest("GET", fmt.Sprintf("%s/automation-servers/token", automationConfig.AOCUrl), nil, automationConfig.AccessToken)
 		if err != nil {
 			return fmt.Errorf("error sending request: %w", err)
 		}
@@ -714,7 +714,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to marshal JSON: %w", err)
 		}
 
-		resp, err = sendRequest("POST", fmt.Sprintf("%s/api/workspaces/", automationConfig.AOCUrl), jsonBytes, automationConfig.AccessToken)
+		resp, err = sendRequest("POST", fmt.Sprintf("%s/workspaces/", automationConfig.AOCUrl), jsonBytes, automationConfig.AccessToken)
 		if err != nil {
 			return fmt.Errorf("error sending request: %w", err)
 		}
@@ -749,7 +749,7 @@ func (o *initOptions) run(cmd *cobra.Command, args []string) error {
 		aocEnvVars = append(aocEnvVars, "BITSWAN_AOC_TOKEN="+automationServerTokenResponse.Token)
 
 		fmt.Println("Getting EMQX JWT for workspace...")
-		resp, err = sendRequest("GET", fmt.Sprintf("%s/api/workspaces/%d/emqx/jwt", automationConfig.AOCUrl, workspacePostResponse.Id), nil, automationConfig.AccessToken)
+		resp, err = sendRequest("GET", fmt.Sprintf("%s/workspaces/%d/emqx/jwt", automationConfig.AOCUrl, workspacePostResponse.Id), nil, automationConfig.AccessToken)
 		if err != nil {
 			return fmt.Errorf("error sending request: %w", err)
 		}

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -122,7 +122,7 @@ func newRegisterCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&serverName, "name", "", "Server name")
-	cmd.Flags().StringVar(&aocUrl, "aoc", "api.bitswan.space", "Automation operation server URL")
+	cmd.Flags().StringVar(&aocUrl, "aoc", "https://api.bitswan.space", "Automation operation server URL")
 
 	return cmd
 }

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -52,7 +52,7 @@ func newRegisterCmd() *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			resp, err := sendRequest("POST", fmt.Sprintf("%s/api/cli/register/", aocUrl), nil, "")
+			resp, err := sendRequest("POST", fmt.Sprintf("%s/cli/register/", aocUrl), nil, "")
 			if err != nil {
 				return fmt.Errorf("error sending request: %w", err)
 			}
@@ -72,7 +72,7 @@ func newRegisterCmd() *cobra.Command {
 			fmt.Printf("Please visit the following URL to authorize the device:\n%s\n", deviceAuthorizationResponse.VerificationURIComplete)
 
 			for {
-				resp, err = sendRequest("GET", fmt.Sprintf("%s/api/cli/register?device_code=%s&server_name=%s", aocUrl, deviceAuthorizationResponse.DeviceCode, serverName), nil, "")
+				resp, err = sendRequest("GET", fmt.Sprintf("%s/cli/register?device_code=%s&server_name=%s", aocUrl, deviceAuthorizationResponse.DeviceCode, serverName), nil, "")
 				if err != nil {
 					return fmt.Errorf("error sending request: %w", err)
 				}
@@ -121,8 +121,8 @@ func newRegisterCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&serverName, "server-name", "", "Server name")
-	cmd.Flags().StringVar(&aocUrl, "aoc", "", "Automation operation server URL")
+	cmd.Flags().StringVar(&serverName, "name", "", "Server name")
+	cmd.Flags().StringVar(&aocUrl, "aoc", "api.bitswan.space", "Automation operation server URL")
 
 	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -121,7 +121,7 @@ func updateGitops(workspaceName string, o *updateOptions) error {
 
 		fmt.Println("Getting automation server token...")
 
-		resp, err := sendRequest("GET", fmt.Sprintf("%s/api/automation-servers/token", automationConfig.AOCUrl), nil, automationConfig.AccessToken)
+		resp, err := sendRequest("GET", fmt.Sprintf("%s/automation-servers/token", automationConfig.AOCUrl), nil, automationConfig.AccessToken)
 		if err != nil {
 			return fmt.Errorf("error sending request: %w", err)
 		}


### PR DESCRIPTION
Remove /api from URLs in init, update and register command
Rename --server-name parameter to --name